### PR TITLE
fix(conf.py): use `repo_folder`, not `github_folder`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ html_context = {
     # Docs location in the repo; used in links for viewing the source files
     #
     # TODO: To customise the directory, uncomment and update as needed.
-    "github_folder": "/docs/",
+    "repo_folder": "/docs/",
     # TODO: To enable or disable the Previous / Next buttons at the bottom of pages
     # Valid options: none, prev, next, both
     "sequential_nav": "both",


### PR DESCRIPTION
conf.py setting `github_folder` is deprecated. Use `repo_folder` instead.