### PR TITLE
fix: 404 url fix

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,7 +155,7 @@ html_context = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'chisel'
 
 
 # Template and asset locations


### PR DESCRIPTION
As Chisel docs are on documentation.ubuntu.com 404 pages do not render properly without the slug defined in `conf.py`