### PR TITLE
chore: Add more visible direct link to rendered docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Chisel documentation
 
-Documentation pages for Chisel.
+Sources for building the [Chisel documentation].
 
 
 ## Chisel repositories
@@ -84,6 +84,7 @@ To contact the maintainers for any purposes, please use the [Chisel room in Matr
 
 <!-- LINKS -->
 
+[Chisel documentation]: https://documentation.ubuntu.com/chisel/en/latest
 [Canonical contributor license agreement]: https://ubuntu.com/legal/contributors
 [Chisel room in Matrix]: https://matrix.to/#/#chisel:ubuntu.com
 [Conventional Commits v1.0.0]: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Minor UX improvement. The reader that visits this repo may appreciate an easily identifiable link to the docs deployed online.

While there is a badge with this link directly above, a "passing" badge wasn't my first instinct as a link to rendered docs. I had skimmed the README and also looked at the top-right of the main repo page (_which links to the `chisel` github repo instead of docs_), and saw nothing to direct the reader to the rendered docs, only to build locally.