### PR TITLE
fix: pinned myst-parser package version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 canonical-sphinx>=0.5.1
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser
+myst-parser~=4.0
 sphinx-autobuild
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
myst-parser released [5.0.0](https://pypi.org/project/myst-parser/5.0.0/) today and caused failures when installing documentation requirements (Python >=3.11):

This PR pins it v4.0, as v5.0.0 causes version conflicts.
