### PR TITLE
fix: correct formatting package slices link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Chisel
 
-**Chisel** is a developer tool for extracting highly customized and specialized ({{package_slices}}) of Ubuntu packages to create 
+**Chisel** is a developer tool for extracting highly customized and specialized [package slices](slices_explanation) of Ubuntu packages to create 
 compact, secure software.
 
 Users need to be able to create software suited to their specific needs with a reduced attack 


### PR DESCRIPTION
"Package slices" had incorrect formatting in `index.md`. This PR fixes this.