### PR TITLE
fix: updating badge after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation Status](https://readthedocs.com/projects/canonical-chisel/badge/?version=latest)](https://canonical-chisel.readthedocs-hosted.com/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.com/projects/canonical-chisel-migration/badge/?version=latest)](https://ubuntu.com/chisel/docs/latest/?badge=latest)
 
 # Chisel documentation
 


### PR DESCRIPTION
The previous badge showed docs status as unknown. This was due to the Chisel documentation URL migration, as we changed RTD project and URL. I have updated it with the new RTD project and link. It is now passing:

<img width="988" height="691" alt="image" src="https://github.com/user-attachments/assets/5426c419-dc05-490b-95d4-aaee64986601" />


