### PR TITLE
docs: Update Chisel documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ To contact the maintainers for any purposes, please use the [Chisel room in Matr
 
 <!-- LINKS -->
 
-[Chisel documentation]: https://documentation.ubuntu.com/chisel/en/latest
+[Chisel documentation]: https://ubuntu.com/chisel/docs
 [Canonical contributor license agreement]: https://ubuntu.com/legal/contributors
 [Chisel room in Matrix]: https://matrix.to/#/#chisel:ubuntu.com
 [Conventional Commits v1.0.0]: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Updates the Chisel documentation link to the migrated URL.